### PR TITLE
Prioritize hint and rainbow training

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ You can edit your configuration in `config.json`
   "priority_stat": ["spd", "sta", "wit", "pwr", "guts"],
   "minimum_mood": "NORMAL",
   "maximum_failure": 10,
-  "prioritize_g1_race": false
+  "prioritize_g1_race": false,
+  "screen_region": [0, 0, 1920, 1080]
 }
 ```
 
@@ -81,6 +82,11 @@ Example: 10 means the bot will avoid training with more than 10% failure risk.
 
 If `true`, the bot will prioritize G1 races except during July and August (summer).
 Useful for fan farming.
+
+`screen_region` (array of four integers)
+
+Defines the area of the screen where Umamusume is running in the format `[left, top, width, height]`.
+Set this if you have multiple monitors so the bot only looks at the game window.
 
 Make sure the values match exactly as expected, typos might cause errors.
 

--- a/config.json
+++ b/config.json
@@ -3,11 +3,12 @@
   "minimum_mood": "NORMAL",
   "maximum_failure": 10,
   "prioritize_g1_race": false,
+  "screen_region": [0, 0, 1920, 1080],
   "stat_caps": {
-  "spd": 1100,
-  "sta": 600,
-  "pwr": 600,
-  "guts": 600,
-  "wit": 1100
+    "spd": 1100,
+    "sta": 600,
+    "pwr": 600,
+    "guts": 600,
+    "wit": 1100
   }
 }

--- a/core/execute.py
+++ b/core/execute.py
@@ -23,9 +23,22 @@ with open("config.json", "r", encoding="utf-8") as file:
 
 MINIMUM_MOOD = config["minimum_mood"]
 PRIORITIZE_G1_RACE = config["prioritize_g1_race"]
+GAME_REGION = tuple(config.get("screen_region", [0, 0, 1920, 1080]))
+OFFSET_X, OFFSET_Y = GAME_REGION[0], GAME_REGION[1]
+
+
+def in_lobby_screen():
+  return (
+    pyautogui.locateCenterOnScreen(
+      "assets/ui/tazuna_hint.png", confidence=0.8, minSearchTime=0.2, region=GAME_REGION
+    )
+    is not None
+  )
 
 def click(img, confidence = 0.8, minSearch = 2, click = 1, text = ""):
-  btn = pyautogui.locateCenterOnScreen(img, confidence=confidence, minSearchTime=minSearch)
+  btn = pyautogui.locateCenterOnScreen(
+    img, confidence=confidence, minSearchTime=minSearch, region=GAME_REGION
+  )
   if btn:
     if text:
       print(text)
@@ -49,7 +62,7 @@ def check_training():
   results = {}
 
   for key, icon_path in training_types.items():
-    pos = pyautogui.locateCenterOnScreen(icon_path, confidence=0.8)
+    pos = pyautogui.locateCenterOnScreen(icon_path, confidence=0.8, region=GAME_REGION)
     if pos:
       pyautogui.moveTo(pos, duration=0.1)
       pyautogui.mouseDown()
@@ -71,13 +84,19 @@ def check_training():
   return results
 
 def do_train(train):
-  train_btn = pyautogui.locateCenterOnScreen(f"assets/icons/train_{train}.png", confidence=0.8)
+  train_btn = pyautogui.locateCenterOnScreen(
+    f"assets/icons/train_{train}.png", confidence=0.8, region=GAME_REGION
+  )
   if train_btn:
     pyautogui.tripleClick(train_btn, interval=0.1, duration=0.2)
 
 def do_rest():
-  rest_btn = pyautogui.locateCenterOnScreen("assets/buttons/rest_btn.png", confidence=0.8)
-  rest_summber_btn = pyautogui.locateCenterOnScreen("assets/buttons/rest_summer_btn.png", confidence=0.8)
+  rest_btn = pyautogui.locateCenterOnScreen(
+    "assets/buttons/rest_btn.png", confidence=0.8, region=GAME_REGION
+  )
+  rest_summber_btn = pyautogui.locateCenterOnScreen(
+    "assets/buttons/rest_summer_btn.png", confidence=0.8, region=GAME_REGION
+  )
 
   if rest_btn:
     pyautogui.moveTo(rest_btn, duration=0.15)
@@ -87,8 +106,12 @@ def do_rest():
     pyautogui.click(rest_summber_btn)
 
 def do_recreation():
-  recreation_btn = pyautogui.locateCenterOnScreen("assets/buttons/recreation_btn.png", confidence=0.8)
-  recreation_summer_btn = pyautogui.locateCenterOnScreen("assets/buttons/rest_summer_btn.png", confidence=0.8)
+  recreation_btn = pyautogui.locateCenterOnScreen(
+    "assets/buttons/recreation_btn.png", confidence=0.8, region=GAME_REGION
+  )
+  recreation_summer_btn = pyautogui.locateCenterOnScreen(
+    "assets/buttons/rest_summer_btn.png", confidence=0.8, region=GAME_REGION
+  )
 
   if recreation_btn:
     pyautogui.moveTo(recreation_btn, duration=0.15)
@@ -126,7 +149,7 @@ def race_day():
   after_race()
 
 def race_select(prioritize_g1 = False):
-  pyautogui.moveTo(x=560, y=680)
+  pyautogui.moveTo(x=OFFSET_X + 560, y=OFFSET_Y + 680)
 
   time.sleep(0.2)
 
@@ -138,13 +161,17 @@ def race_select(prioritize_g1 = False):
       if race_card:
         for x, y, w, h in race_card:
           region = (x, y, 310, 90)
-          match_aptitude = pyautogui.locateCenterOnScreen("assets/ui/match_track.png", confidence=0.8, minSearchTime=0.7, region=region)
+          match_aptitude = pyautogui.locateCenterOnScreen(
+            "assets/ui/match_track.png", confidence=0.8, minSearchTime=0.7, region=region
+          )
           if match_aptitude:
             print("[INFO] G1 race found.")
             pyautogui.moveTo(match_aptitude, duration=0.2)
             pyautogui.click()
             for i in range(2):
-              race_btn = pyautogui.locateCenterOnScreen("assets/buttons/race_btn.png", confidence=0.8, minSearchTime=2)
+              race_btn = pyautogui.locateCenterOnScreen(
+                "assets/buttons/race_btn.png", confidence=0.8, minSearchTime=2, region=GAME_REGION
+              )
               if race_btn:
                 pyautogui.moveTo(race_btn, duration=0.2)
                 pyautogui.click(race_btn)
@@ -158,14 +185,18 @@ def race_select(prioritize_g1 = False):
   else:
     print("[INFO] Looking for race.")
     for i in range(4):
-      match_aptitude = pyautogui.locateCenterOnScreen("assets/ui/match_track.png", confidence=0.8, minSearchTime=0.7)
+      match_aptitude = pyautogui.locateCenterOnScreen(
+        "assets/ui/match_track.png", confidence=0.8, minSearchTime=0.7, region=GAME_REGION
+      )
       if match_aptitude:
         print("[INFO] Race found.")
         pyautogui.moveTo(match_aptitude, duration=0.2)
         pyautogui.click(match_aptitude)
 
         for i in range(2):
-          race_btn = pyautogui.locateCenterOnScreen("assets/buttons/race_btn.png", confidence=0.8, minSearchTime=2)
+          race_btn = pyautogui.locateCenterOnScreen(
+            "assets/buttons/race_btn.png", confidence=0.8, minSearchTime=2, region=GAME_REGION
+          )
           if race_btn:
             pyautogui.moveTo(race_btn, duration=0.2)
             pyautogui.click(race_btn)
@@ -178,7 +209,9 @@ def race_select(prioritize_g1 = False):
     return False
 
 def race_prep():
-  view_result_btn = pyautogui.locateCenterOnScreen("assets/buttons/view_results.png", confidence=0.8, minSearchTime=20)
+  view_result_btn = pyautogui.locateCenterOnScreen(
+    "assets/buttons/view_results.png", confidence=0.8, minSearchTime=20, region=GAME_REGION
+  )
   if view_result_btn:
     pyautogui.click(view_result_btn)
     time.sleep(0.5)
@@ -210,16 +243,16 @@ def career_lobby():
       continue
 
     # Check if current menu is in career lobby
-    tazuna_hint = pyautogui.locateCenterOnScreen("assets/ui/tazuna_hint.png", confidence=0.8, minSearchTime=0.2)
-
-    if tazuna_hint is None:
-      print("[INFO] Should be in career lobby.")
+    if not in_lobby_screen():
+      print("[INFO] Waiting for lobby screen.")
       continue
 
     time.sleep(0.5)
 
     # Check if there is debuff status
-    debuffed = pyautogui.locateOnScreen("assets/buttons/infirmary_btn2.png", confidence=0.9, minSearchTime=1)
+    debuffed = pyautogui.locateOnScreen(
+      "assets/buttons/infirmary_btn2.png", confidence=0.9, minSearchTime=1, region=GAME_REGION
+    )
     if debuffed:
       if is_infirmary_active((debuffed.left, debuffed.top, debuffed.width, debuffed.height)):
         pyautogui.click(debuffed)

--- a/core/execute.py
+++ b/core/execute.py
@@ -4,7 +4,15 @@ import json
 
 pyautogui.useImageNotFoundException(False)
 
-from core.state import check_support_card, check_failure, check_turn, check_mood, check_current_year, check_criteria
+from core.state import (
+  check_support_card,
+  check_failure,
+  check_turn,
+  check_mood,
+  check_current_year,
+  check_criteria,
+  check_hint,
+)
 from core.logic import do_something
 from utils.constants import MOOD_LIST
 from core.recognizer import is_infirmary_active, match_template
@@ -48,12 +56,14 @@ def check_training():
       support_counts = check_support_card()
       total_support = sum(support_counts.values())
       failure_chance = check_failure()
+      hint_count = check_hint()
       results[key] = {
         "support": support_counts,
         "total_support": total_support,
-        "failure": failure_chance
+        "failure": failure_chance,
+        "hint": hint_count,
       }
-      print(f"[{key.upper()}] → {support_counts}, Fail: {failure_chance}%")
+      print(f"[{key.upper()}] → {support_counts}, Hint: {hint_count}, Fail: {failure_chance}%")
       time.sleep(0.1)
   
   pyautogui.mouseUp()

--- a/core/logic.py
+++ b/core/logic.py
@@ -1,6 +1,6 @@
 import json
 
-from core.state import check_current_year, stat_state
+from core.state import stat_state
 
 with open("config.json", "r", encoding="utf-8") as file:
   config = json.load(file)
@@ -91,6 +91,29 @@ def rainbow_training(results):
   print(f"\n[INFO] Rainbow training selected: {best_key.upper()} with {best_data['support'][best_key]} rainbow supports and {best_data['failure']}% fail chance")
   return best_key
 
+# Do hint training
+def hint_training(results):
+  hint_candidates = {
+    stat: data for stat, data in results.items()
+    if int(data["failure"]) <= MAX_FAILURE and data.get("hint", 0) > 0
+  }
+
+  if not hint_candidates:
+    print("\n[INFO] No hint training found under failure threshold.")
+    return None
+
+  best_hint = max(
+    hint_candidates.items(),
+    key=lambda x: (
+      x[1]["hint"],
+      -get_stat_priority(x[0])
+    )
+  )
+
+  best_key, best_data = best_hint
+  print(f"\n[INFO] Hint training selected: {best_key.upper()} with {best_data['hint']} hints and {best_data['failure']}% fail chance")
+  return best_key
+
 def filter_by_stat_caps(results, current_stats):
   return {
     stat: data for stat, data in results.items()
@@ -99,7 +122,6 @@ def filter_by_stat_caps(results, current_stats):
   
 # Decide training
 def do_something(results):
-  year = check_current_year()
   current_stats = stat_state()
   print(f"Current stats: {current_stats}")
 
@@ -109,11 +131,12 @@ def do_something(results):
     print("[INFO] All stats capped or no valid training.")
     return None
 
-  if "Junior Year" in year:
-    return most_support_card(filtered)
-  else:
-    result = rainbow_training(filtered)
-    if result is None:
-      print("[INFO] Falling back to most_support_card because rainbow not available.")
-      return most_support_card(filtered)
-  return result
+  result = hint_training(filtered)
+  if result:
+    return result
+
+  result = rainbow_training(filtered)
+  if result:
+    return result
+
+  return most_support_card(filtered)

--- a/core/recognizer.py
+++ b/core/recognizer.py
@@ -1,15 +1,31 @@
 import cv2
+import json
 import numpy as np
 from PIL import ImageGrab, ImageStat
 
 from utils.screenshot import capture_region
 
+with open("config.json", "r", encoding="utf-8") as file:
+  config = json.load(file)
+
+SCREEN_REGION = config.get("screen_region", [0, 0, 1920, 1080])
+OFFSET_X, OFFSET_Y, WIDTH, HEIGHT = (
+  SCREEN_REGION[0], SCREEN_REGION[1], SCREEN_REGION[2], SCREEN_REGION[3]
+)
+
+
 def match_template(template_path, region=None, threshold=0.85):
   # Get screenshot
   if region:
-    screen = np.array(ImageGrab.grab(bbox=region))  # (left, top, right, bottom)
+    left = OFFSET_X + region[0]
+    top = OFFSET_Y + region[1]
+    right = left + region[2]
+    bottom = top + region[3]
+    screen = np.array(ImageGrab.grab(bbox=(left, top, right, bottom)))
   else:
-    screen = np.array(ImageGrab.grab())
+    screen = np.array(
+      ImageGrab.grab(bbox=(OFFSET_X, OFFSET_Y, OFFSET_X + WIDTH, OFFSET_Y + HEIGHT))
+    )
   screen = cv2.cvtColor(screen, cv2.COLOR_RGB2BGR)
 
   # Load template

--- a/core/state.py
+++ b/core/state.py
@@ -43,6 +43,12 @@ def check_support_card(threshold=0.8):
 
   return count_result
 
+# Check hint icon in each training
+def check_hint(threshold=0.8):
+  hint_icon = "assets/icons/hint_icon.png"
+  matches = match_template(hint_icon, SUPPORT_CARD_ICON_REGION, threshold)
+  return len(matches)
+
 # Get failure chance (idk how to get energy value)
 def check_failure():
   failure = enhanced_screenshot(FAILURE_REGION)

--- a/utils/scenario.py
+++ b/utils/scenario.py
@@ -1,6 +1,16 @@
+import json
 import pyautogui
 
+with open("config.json", "r", encoding="utf-8") as file:
+  config = json.load(file)
+
+GAME_REGION = tuple(config.get("screen_region", [0, 0, 1920, 1080]))
+
+
 def ura():
-  race_btn = pyautogui.locateCenterOnScreen("assets/ura/ura_race_btn.png", confidence=0.8, minSearchTime=0.2)
+  race_btn = pyautogui.locateCenterOnScreen(
+    "assets/ura/ura_race_btn.png", confidence=0.8, minSearchTime=0.2, region=GAME_REGION
+  )
   if race_btn:
     pyautogui.click(race_btn)
+

--- a/utils/screenshot.py
+++ b/utils/screenshot.py
@@ -1,14 +1,22 @@
 from PIL import Image, ImageEnhance
+import json
 import mss
 import numpy as np
+
+with open("config.json", "r", encoding="utf-8") as file:
+  config = json.load(file)
+
+SCREEN_REGION = config.get("screen_region", [0, 0, 1920, 1080])
+OFFSET_X, OFFSET_Y = SCREEN_REGION[0], SCREEN_REGION[1]
+
 
 def enhanced_screenshot(region=(0, 0, 1920, 1080)) -> Image.Image:
   with mss.mss() as sct:
     monitor = {
-      "left": region[0],
-      "top": region[1],
+      "left": OFFSET_X + region[0],
+      "top": OFFSET_Y + region[1],
       "width": region[2],
-      "height": region[3]
+      "height": region[3],
     }
     img = sct.grab(monitor)
     img_np = np.array(img)
@@ -21,13 +29,14 @@ def enhanced_screenshot(region=(0, 0, 1920, 1080)) -> Image.Image:
 
   return pil_img
 
+
 def capture_region(region=(0, 0, 1920, 1080)) -> Image.Image:
   with mss.mss() as sct:
     monitor = {
-      "left": region[0],
-      "top": region[1],
+      "left": OFFSET_X + region[0],
+      "top": OFFSET_Y + region[1],
       "width": region[2],
-      "height": region[3]
+      "height": region[3],
     }
     img = sct.grab(monitor)
     img_np = np.array(img)


### PR DESCRIPTION
## Summary
- detect hint icons during training checks
- choose hint or rainbow trainings before other options
- add placeholder image for hint icon

## Testing
- `python -m py_compile core/state.py core/execute.py core/logic.py`


------
https://chatgpt.com/codex/tasks/task_e_68963119d6bc8331bb52ee04fca6e28f